### PR TITLE
add -e option to expand literal \[nt]s into whitespace

### DIFF
--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -85,9 +85,12 @@ class Message(dict):
             action_url=None,
             notes_url=None,
             status_cgi_url='',
-            extinfo_cgi_url=''
+            extinfo_cgi_url='',
+            expand=False
     ):
         fields = AttachmentFieldList()
+        if expand:
+            message = message.replace(r'\n', "\n").replace(r'\t', "\t")
 
         host_notification = bool(host_state)
 
@@ -242,6 +245,12 @@ def parse_options():
         help="Username to send the message from {default: Icinga}"
     )
     parser.add_argument(
+        '-e',
+        action='store_true',
+        default=False,
+        help="Enable interpretation of backslash escapes"
+    )
+    parser.add_argument(
         '-V', '--version',
         action='version',
         help="Print version information",
@@ -266,7 +275,8 @@ def main():
         action_url=args.service_action_url,
         notes_url=args.service_notes_url,
         status_cgi_url=args.status_cgi_url,
-        extinfo_cgi_url=args.extinfo_cgi_url
+        extinfo_cgi_url=args.extinfo_cgi_url,
+        expand=args.e
     )
 
     if args.print_payload:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -77,6 +77,13 @@ class TestMessage(TestCommon):
         self.message.attach("message", "hostname.domain", "CRITICAL")
         self.assertEqual(len(self.message['attachments']), 1)
 
+    def test_message_attachment_expand(self):
+        self.message = Message("#webops", "test message", "username")
+        self.message.attach(r'foo\nbar', "hostname.domain", "CRITICAL", expand=True)
+        self.message.attach(r'foo\nbar', "hostname.domain", "CRITICAL", expand=False)
+        self.assertTrue('foo\nbar' in self.message['attachments'][0]['text'])
+        self.assertTrue(r'foo\nbar' in self.message['attachments'][1]['text'])
+
     def test_message_multiple_attachment(self):
         self.message = Message("#webops", "username", "test message")
         self.message.attach("message", "hostname.domain", "CRITICAL")


### PR DESCRIPTION
When `icinga_slack_webhook_notify` is called as an icinga command there is no
shell to expand \n & \t into whitespace.  The -e option expands these literals,
if present, in the -m string.
