### PR TITLE
Improve the display and content of messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,26 +17,37 @@ Usage
 -----
 
 ::
-
-    usage: icinga_slack_webhook_notify [-h] -c CHANNEL -m MESSAGE -s SUBDOMAIN -t TOKEN
-                                       [-A SERVICEACTIONURL] [-H HOST] [-L LEVEL]
-                                       [-M HEADERMESSAGE] [-N SERVICENOTESURL] [-S STATUSCGIURL]
-                                       [-U USERNAME]
+    usage: icinga_slack_webhook_notify [-h] -c CHANNEL -m MESSAGE [-u WEB_HOOK_URL | -p]
+                                       [-A SERVICE_ACTION_URL] [-H HOST] [-d HOST_DISPLAY_NAME]
+                                       [-L {OK,WARNING,CRITICAL,UNKNOWN}] [-N SERVICE_NOTES_URL]
+                                       [-S STATUS_CGI_URL] [-E EXTINFO_CGI_URL] [-U USERNAME]
+                                       [-V]
 
     Send an Icinga Alert to Slack.com via a generic webhook integration
 
     optional arguments:
-      -h, --help           show this help message and exit
-      -c CHANNEL           The channel to send the message to
-      -m MESSAGE           The text of the message to send
-      -u WEBHOOKURL        The webhook URL for your integration
-      -A SERVICEACTIONURL  An optional action_url for this alert {default: None}
-      -H HOST              An optional host the message relates to {default: UNKNOWN}
-      -L LEVEL             An optional alert level {default: UNKNOWN}
-      -M HEADERMESSAGE     A header message sent before the formatted alert
-                           {default: I have received the following alert:}
-      -N SERVICENOTESURL   An optional notes_url for this alert {default: None}
-      -S STATUSCGIURL      The URL of status.cgi for your Nagios/Icinga instance
-                           {default: https://nagios.example.com/cgi-bin/icinga/status.cgi}
-      -U USERNAME          Username to send the message from {default: Icinga}
-      -V                   Print version information
+      -h, --help            show this help message and exit
+      -c CHANNEL, --channel CHANNEL
+                            The channel to send the message to
+      -m MESSAGE, --message MESSAGE
+                            The text of the message to send
+      -u WEB_HOOK_URL, --web-hook-url WEB_HOOK_URL
+                            The webhook URL for your integration
+      -p, --print-payload   Rather than sending the payload to Slack, print it to STDOUT
+      -A SERVICE_ACTION_URL, --service-action-url SERVICE_ACTION_URL
+                            An optional action_url for this alert {default: None}
+      -H HOST, --host HOST  An optional host the message relates to
+      -d HOST_DISPLAY_NAME, --host-display-name HOST_DISPLAY_NAME
+                            An optional display name for the host the message relates to
+      -L {OK,WARNING,CRITICAL,UNKNOWN}, --level {OK,WARNING,CRITICAL,UNKNOWN}
+                            An optional alert level {default: UNKNOWN}
+      -N SERVICE_NOTES_URL, --service-notes-url SERVICE_NOTES_URL
+                            An optional notes_url for this alert {default: None}
+      -S STATUS_CGI_URL, --status-cgi-url STATUS_CGI_URL
+                            The URL of status.cgi for your Nagios/Icinga instance {default:
+                            https://nagios.example.com/cgi-bin/icinga/status.cgi}
+      -E EXTINFO_CGI_URL, --extinfo-cgi-url EXTINFO_CGI_URL
+                            The URL of extinfo.cgi for your Nagios/Icinga instance
+      -U USERNAME, --username USERNAME
+                            Username to send the message from {default: Icinga}
+      -V, --version         Print version information

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Usage
 ::
     usage: icinga_slack_webhook_notify [-h] -c CHANNEL -m MESSAGE [-u WEB_HOOK_URL | -p]
                                        [-A SERVICE_ACTION_URL] [-H HOST] [-d HOST_DISPLAY_NAME]
+                                       [--host-state HOST_STATE]
                                        [-L {OK,WARNING,CRITICAL,UNKNOWN}] [-N SERVICE_NOTES_URL]
                                        [-S STATUS_CGI_URL] [-E EXTINFO_CGI_URL] [-U USERNAME]
                                        [-V]
@@ -39,6 +40,8 @@ Usage
       -H HOST, --host HOST  An optional host the message relates to
       -d HOST_DISPLAY_NAME, --host-display-name HOST_DISPLAY_NAME
                             An optional display name for the host the message relates to
+      --host-state HOST_STATE
+                            An optional state the host is in, use this for host alerts
       -L {OK,WARNING,CRITICAL,UNKNOWN}, --level {OK,WARNING,CRITICAL,UNKNOWN}
                             An optional alert level {default: UNKNOWN}
       -N SERVICE_NOTES_URL, --service-notes-url SERVICE_NOTES_URL

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -39,8 +39,9 @@ class AttachmentFieldList(list):
 
 
 class Attachment(dict):
-    def __init__(self, fallback, fields, text=None, pretext=None, color=None):
+    def __init__(self, fallback, fields, mrkdwn_in=[], text=None, pretext=None, color=None):
         self['fallback'] = fallback
+        self['mrkdwn_in'] = mrkdwn_in
         self['fields'] = fields
         if text:
             self['text'] = text

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -50,12 +50,10 @@ class AttachmentList(list):
 
 
 class Message(dict):
-    def __init__(self, channel, text, username, mrkdwn_in=["fields"],
+    def __init__(self, channel, text, username,
                  icon_emoji=":ghost:", attachments=None):
         self['channel'] = channel
         self['text'] = text
-        if mrkdwn_in:
-            self['mrkdwn_in'] = mrkdwn_in
         if username:
             self['username'] = username
         if icon_emoji:

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -102,10 +102,13 @@ class Message(dict):
 
         if host_display_name or host:
             host_and_service_text.append(
-                "*Host:* " +  abbreviate_url("{0}?host={1}".format(
-                    status_cgi_url,
-                    host_display_name
-                ))
+                "*Host:* " +  abbreviate_url(
+                    "{0}?host={1}".format(
+                        status_cgi_url,
+                        host_display_name
+                    ),
+                    label=host_display_name
+                )
             )
 
         fields.append(

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -73,9 +73,12 @@ class Message(dict):
     ):
         fields = AttachmentFieldList()
         fields.append(AttachmentField("Message", message))
-        fields.append(AttachmentField(
-            "Host", "<{1}?host={0}|{0}>".format(host, status_cgi_url),
-            True)
+        fields.append(
+            AttachmentField(
+                "Host",
+                abbreviate_url("{0}?host={1}".format(status_cgi_url, host)),
+                True
+            )
         )
         fields.append(AttachmentField("Level", level, True))
         if action_url:

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -18,13 +18,13 @@ alert_colors = {'UNKNOWN': '#6600CC',
 
 MAX_URL_LENGTH = 22
 
-def abbreviate_url(url, label=None):
+def abbreviate_url(url, label=None, max_url_length=MAX_URL_LENGTH):
     parsed_url = urllib.parse.urlparse(url)
 
     if label is None:
         label = parsed_url.netloc
 
-    if len(label) > MAX_URL_LENGTH:
+    if max_url_length is not None and len(label) > MAX_URL_LENGTH:
         label = (label[:MAX_URL_LENGTH - 2] + '..')
 
     return "<{0}|{1}>".format(url, label)

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -89,22 +89,65 @@ def parse_options():
         prog="icinga_slack_webhook_notify",
         description="Send an Icinga Alert to Slack.com via a generic webhook integration"
     )
-    parser.add_argument('-c', metavar="CHANNEL", type=str, required=True, help="The channel to send the message to")
-    parser.add_argument('-m', metavar="MESSAGE", type=str, required=True, help="The text of the message to send")
-    parser.add_argument('-u', metavar="WEBHOOKURL", type=str, required=True, help="The webhook URL for your integration")
-    parser.add_argument('-A', metavar="SERVICEACTIONURL", type=str, default=None, help="An optional action_url for this alert {default: None}")
-    parser.add_argument('-H', metavar="HOST", type=str, default="UNKNOWN", help="An optional host the message relates to {default: UNKNOWN}")
-    parser.add_argument('-L', metavar="LEVEL", type=str, choices=["OK", "WARNING", "CRITICAL", "UNKNOWN"], default="UNKNOWN",
-                        help="An optional alert level {default: UNKNOWN}")
-    parser.add_argument('-M', metavar="HEADERMESSAGE", type=str, default="I have received the following alert:",
-                        help="A header message sent before the formatted alert {default: I have received the following alert:}")
-    parser.add_argument('-N', metavar="SERVICENOTESURL", type=str, default=None, help="An optional notes_url for this alert {default: None}")
-    parser.add_argument('-S', metavar="STATUSCGIURL", type=str, default='https://nagios.example.com/cgi-bin/icinga/status.cgi',
-                        help="The URL of status.cgi for your Nagios/Icinga instance {default: https://nagios.example.com/cgi-bin/icinga/status.cgi}")
-    parser.add_argument('-U', metavar="USERNAME", type=str, default="Icinga", help="Username to send the message from {default: Icinga}")
-    parser.add_argument('-V', action='version', help="Print version information", version="version: {0}".format(__version__))
-    args = parser.parse_args()
-    return args
+    parser.add_argument(
+        '-c', '--channel',
+        required=True,
+        help="The channel to send the message to"
+    )
+    parser.add_argument(
+        '-m', '--message',
+        required=True,
+        help="The text of the message to send"
+    )
+    parser.add_argument(
+        '-u', '--web-hook-url',
+        required=True,
+        help="The webhook URL for your integration"
+    )
+    parser.add_argument(
+        '-A', '--service-action-url',
+        default=None,
+        help="An optional action_url for this alert {default: None}"
+    )
+    parser.add_argument(
+        '-H', '--host',
+        default="UNKNOWN",
+        help="An optional host the message relates to {default: UNKNOWN}"
+    )
+    parser.add_argument(
+        '-L', '--level',
+        choices=["OK", "WARNING", "CRITICAL", "UNKNOWN"],
+        default="UNKNOWN",
+        help="An optional alert level {default: UNKNOWN}"
+    )
+    parser.add_argument(
+        '-M', '--header-message',
+        default="I have received the following alert:",
+        help="A header message sent before the formatted alert {default: I have received the following alert:}"
+    )
+    parser.add_argument(
+        '-N', '--service-notes-url',
+        default=None,
+        help="An optional notes_url for this alert {default: None}"
+    )
+    parser.add_argument(
+        '-S', '--status-cgi-url',
+        default='https://nagios.example.com/cgi-bin/icinga/status.cgi',
+        help="The URL of status.cgi for your Nagios/Icinga instance {default: https://nagios.example.com/cgi-bin/icinga/status.cgi}"
+    )
+    parser.add_argument(
+        '-U', '--username',
+        default="Icinga",
+        help="Username to send the message from {default: Icinga}"
+    )
+    parser.add_argument(
+        '-V', '--version',
+        action='version',
+        help="Print version information",
+        version=__version__
+    )
+
+    return parser.parse_args()
 
 
 def main():

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -18,15 +18,16 @@ alert_colors = {'UNKNOWN': '#6600CC',
 
 MAX_URL_LENGTH = 22
 
-def abbreviate_url(url):
+def abbreviate_url(url, label=None):
     parsed_url = urllib.parse.urlparse(url)
 
-    hostname = parsed_url.netloc
+    if label is None:
+        label = parsed_url.netloc
 
-    if len(hostname) > MAX_URL_LENGTH:
-        hostname = (hostname[:MAX_URL_LENGTH - 2] + '..')
+    if len(label) > MAX_URL_LENGTH:
+        label = (label[:MAX_URL_LENGTH - 2] + '..')
 
-    return "<{0}|{1}>".format(url, hostname)
+    return "<{0}|{1}>".format(url, label)
 
 class AttachmentField(dict):
     def __init__(self, value, title=None, short=False):

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -121,10 +121,17 @@ def parse_options():
         required=True,
         help="The text of the message to send"
     )
-    parser.add_argument(
+    destination_group = parser.add_mutually_exclusive_group()
+    destination_group.add_argument(
         '-u', '--web-hook-url',
-        required=True,
         help="The webhook URL for your integration"
+    )
+    destination_group.add_argument(
+        '-p', '--print-payload',
+        action='store_const',
+        const=True,
+        default=False,
+        help="Rather than sending the payload to Slack, print it to STDOUT"
     )
     parser.add_argument(
         '-A', '--service-action-url',
@@ -176,10 +183,14 @@ def main():
     args = parse_options()
     message = Message(channel=args.c, text=args.M, username=args.U)
     message.attach(message=args.m, host=args.H, level=args.L, action_url=args.A, notes_url=args.N, status_cgi_url=args.S)
-    if message.send(webhook_url=args.u):
-        sys.exit(0)
+
+    if args.print_payload:
+        print(json.dumps(message, indent=True))
     else:
-        sys.exit(1)
+        if message.send(webhook_url=args.web_hook_url):
+            sys.exit(0)
+        else:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -81,9 +81,21 @@ class Message(dict):
         )
         fields.append(AttachmentField("Level", level, True))
         if action_url:
-            fields.append(AttachmentField("Actions URL", action_url, True))
+            fields.append(
+                AttachmentField(
+                    "Actions URL",
+                    abbreviate_url(action_url),
+                    True
+                )
+            )
         if notes_url:
-            fields.append(AttachmentField("Notes URL", notes_url, True))
+            fields.append(
+                AttachmentField(
+                    "Notes URL",
+                    abbreviate_url(notes_url),
+                    True
+                )
+            )
         if level in alert_colors.keys():
             color = alert_colors[level]
         else:

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -13,6 +13,10 @@ alert_colors = {'UNKNOWN': '#6600CC',
                 'WARNING': '#FF9900',
                 'OK': '#36A64F'}
 
+def abbreviate_url(url):
+    parsed_url = urllib.parse.urlparse(url)
+
+    return "<{0}|{1}>".format(url, parsed_url.netloc)
 
 class AttachmentField(dict):
     def __init__(self, title, value, short=False):

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -13,10 +13,17 @@ alert_colors = {'UNKNOWN': '#6600CC',
                 'WARNING': '#FF9900',
                 'OK': '#36A64F'}
 
+MAX_URL_LENGTH = 22
+
 def abbreviate_url(url):
     parsed_url = urllib.parse.urlparse(url)
 
-    return "<{0}|{1}>".format(url, parsed_url.netloc)
+    hostname = parsed_url.netloc
+
+    if len(hostname) > MAX_URL_LENGTH:
+        hostname = (hostname[:MAX_URL_LENGTH - 2] + '..')
+
+    return "<{0}|{1}>".format(url, hostname)
 
 class AttachmentField(dict):
     def __init__(self, title, value, short=False):

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -58,10 +58,21 @@ class Message(dict):
             self['icon_emoji'] = icon_emoji
         self['attachments'] = AttachmentList()
 
-    def attach(self, message, host, level, action_url=None, notes_url=None, status_cgi_url=''):
+    def attach(
+            self,
+            message,
+            host,
+            level,
+            action_url=None,
+            notes_url=None,
+            status_cgi_url=''
+    ):
         fields = AttachmentFieldList()
         fields.append(AttachmentField("Message", message))
-        fields.append(AttachmentField("Host", "<{1}?host={0}|{0}>".format(host, status_cgi_url), True))
+        fields.append(AttachmentField(
+            "Host", "<{1}?host={0}|{0}>".format(host, status_cgi_url),
+            True)
+        )
         fields.append(AttachmentField("Level", level, True))
         if action_url:
             fields.append(AttachmentField("Actions URL", action_url, True))
@@ -71,12 +82,19 @@ class Message(dict):
             color = alert_colors[level]
         else:
             color = alert_colors['UNKNOWN']
-        alert_attachment = Attachment(fallback="    {0} on {1} is {2}".format(message, host, level), color=color, fields=fields)
+        alert_attachment = Attachment(
+            fallback="    {0} on {1} is {2}".format(message, host, level),
+            color=color,
+            fields=fields
+        )
         self['attachments'].append(alert_attachment)
 
     def send(self, webhook_url):
         data = urllib.parse.urlencode({"payload": json.dumps(self)})
-        response = urllib.request.urlopen(webhook_url, data.encode('utf8')).read()
+        response = urllib.request.urlopen(
+            webhook_url,
+            data.encode('utf8')
+        ).read()
         if response == b'ok':
             return True
         else:

--- a/icinga_slack/webhook.py
+++ b/icinga_slack/webhook.py
@@ -72,7 +72,6 @@ class Message(dict):
             status_cgi_url=''
     ):
         fields = AttachmentFieldList()
-        fields.append(AttachmentField("Message", message))
         fields.append(
             AttachmentField(
                 "Host",
@@ -153,11 +152,6 @@ def parse_options():
         help="An optional alert level {default: UNKNOWN}"
     )
     parser.add_argument(
-        '-M', '--header-message',
-        default="I have received the following alert:",
-        help="A header message sent before the formatted alert {default: I have received the following alert:}"
-    )
-    parser.add_argument(
         '-N', '--service-notes-url',
         default=None,
         help="An optional notes_url for this alert {default: None}"
@@ -184,8 +178,17 @@ def parse_options():
 
 def main():
     args = parse_options()
-    message = Message(channel=args.c, text=args.M, username=args.U)
-    message.attach(message=args.m, host=args.H, level=args.L, action_url=args.A, notes_url=args.N, status_cgi_url=args.S)
+    message = Message(
+        channel=args.channel, text=args.message, username=args.username
+    )
+    message.attach(
+        message=args.message,
+        host=args.host,
+        level=args.level,
+        action_url=args.service_action_url,
+        notes_url=args.service_notes_url,
+        status_cgi_url=args.status_cgi_url
+    )
 
     if args.print_payload:
         print(json.dumps(message, indent=True))

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -67,18 +67,18 @@ class TestAttachmentList(TestCommon):
 class TestMessage(TestCommon):
 
     def test_message_mandatory_options(self):
-        self.message = Message("#webops", "test message", "username")
+        self.message = Message("#webops", "username", "test message")
         self.assertEqual(self.message['channel'], "#webops")
         self.assertEqual(self.message['text'], "test message")
         self.assertEqual(self.message['username'], "username")
 
     def test_message_attachment(self):
-        self.message = Message("#webops", "test message", "username")
+        self.message = Message("#webops", "username", "test message")
         self.message.attach("message", "hostname.domain", "CRITICAL")
         self.assertEqual(len(self.message['attachments']), 1)
 
     def test_message_multiple_attachment(self):
-        self.message = Message("#webops", "test message", "username")
+        self.message = Message("#webops", "username", "test message")
         self.message.attach("message", "hostname.domain", "CRITICAL")
         self.message.attach("message2", "hostname.domain", "CRITICAL")
         self.assertEqual(len(self.message['attachments']), 2)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -47,7 +47,7 @@ class TestAttachment(TestCommon):
         self.assertEqual(self.attachment['fields'], self.example_attachment_field_list )
 
     def test_attachment_with_optionals(self):
-        self.attachment = Attachment("Fallback Message", self.example_attachment_field_list, "Text", "Pretext", "#FF0000")
+        self.attachment = Attachment("Fallback Message", self.example_attachment_field_list, [], "Text", "Pretext", "#FF0000")
         self.assertEqual(self.attachment['text'], "Text")
         self.assertEqual(self.attachment['pretext'], "Pretext")
         self.assertEqual(self.attachment['color'], "#FF0000")


### PR DESCRIPTION
## Before

![Screenshot from 2019-05-20 15-49-21](https://user-images.githubusercontent.com/1130010/58037043-02ee8e80-7b1c-11e9-9c4d-97cd638a5dca.png)

## After 

![Screenshot from 2019-05-20 16-24-07](https://user-images.githubusercontent.com/1130010/58037050-084bd900-7b1c-11e9-8b21-80653faf673c.png)

 - Get rid of the "I have revived the following alert:" text, as it doesn't tell you anything, and replace it with the message, prefixed with either the level of the alert, or the status of the affected host
 - Don't use attachment field titles (Host, Actions URL, ...), instead use bold text before the links, as this takes up less vertical space.
 - Use the hostname for links, and truncate it so it fits on a single line
 - Add in a link to the Service, for service alerts. This requires a couple of new parameters to pass the full host and the extinfo_cgi_url information in.