### PR TITLE
ci: Switch to GitHub Actions instead of Travis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.4
+
+      - run: python setup.py install
+      - run: python setup.py test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.4
+          python-version: 3.5
 
       - run: python setup.py install
       - run: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-python:
-      - "3.4"
-install:
-      - python setup.py install
-script:
-      - python setup.py test


### PR DESCRIPTION
- In accordance with [RFC 123](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-123-github-actions-ci.md).
- I've had to diverge slightly from what the Python version is on our infra as it wasn't included by default in Actions, so I've gone for 3.5 - another reason why EoL software is bad!